### PR TITLE
fix vertices mismatch

### DIFF
--- a/honeybee_doe2/properties/groundcontact.py
+++ b/honeybee_doe2/properties/groundcontact.py
@@ -12,7 +12,6 @@ class GroundFloor:
 
     def to_inp(self, space_origin):
 
-        origin_pt = self.face.geometry.lower_left_corner
         azimuth = 180 if self.face.azimuth == 0 else self.face.azimuth
         origin_pt = self.face.geometry.lower_left_corner - space_origin
 
@@ -23,7 +22,6 @@ class GroundFloor:
             short_name(self.face.properties.energy.construction.display_name)))
         obj_lines.append('\n  LOCATION     = BOTTOM')
         obj_lines.append('\n  POLYGON      = "{} Plg"'.format(self.face.display_name))
-        #obj_lines.append('\n  AREA         = {}'.format(self.face.area))
         obj_lines.append('\n  AZIMUTH      = {}'.format(azimuth))
         obj_lines.append('\n  X            = {}'.format(origin_pt.x))
         obj_lines.append('\n  Y            = {}'.format(origin_pt.y))

--- a/honeybee_doe2/properties/groundcontact.py
+++ b/honeybee_doe2/properties/groundcontact.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # -*- Python Version: 2.7 -*-
 from ..utils.doe_formatters import short_name
+from ..geometry.polygon import DoePolygon
 
 # ? Sooo equest is odd, but this is the way with having the undrgnd wall
 # *
@@ -9,19 +10,23 @@ from ..utils.doe_formatters import short_name
 class GroundFloor:
     def __init__(self, face):
         self.face = face
+        self.polygon = DoePolygon.from_face(face, underground_surface=True)
 
     def to_inp(self, space_origin):
 
         azimuth = 180 if self.face.azimuth == 0 else self.face.azimuth
         origin_pt = self.face.geometry.lower_left_corner - space_origin
 
-        obj_lines = []
+        # create a unique polygon for ground floor faces
+        polygon_name = f'{self.face.display_name}_ug Plg'
+        polygon = self.polygon.to_inp(name=polygon_name) + '\n'
+        obj_lines = [polygon]
         obj_lines.append(
             '"{}" = UNDERGROUND-WALL'.format(short_name(self.face.display_name)))
         obj_lines.append('\n  CONSTRUCTION = "{}_c"'.format(
             short_name(self.face.properties.energy.construction.display_name)))
         obj_lines.append('\n  LOCATION     = BOTTOM')
-        obj_lines.append('\n  POLYGON      = "{} Plg"'.format(self.face.display_name))
+        obj_lines.append('\n  POLYGON      = "{}"'.format(polygon_name))
         obj_lines.append('\n  AZIMUTH      = {}'.format(azimuth))
         obj_lines.append('\n  X            = {}'.format(origin_pt.x))
         obj_lines.append('\n  Y            = {}'.format(origin_pt.y))

--- a/honeybee_doe2/properties/roof.py
+++ b/honeybee_doe2/properties/roof.py
@@ -1,9 +1,8 @@
 from ladybug_geometry.geometry3d.face import Face3D
 from ..utils.doe_formatters import short_name
-from ..geometry.polygon import DoePolygon
 
 
-class DoeRoofObj:
+class DoeRoof:
     def __init__(self, face):
         self.face = face
 

--- a/honeybee_doe2/properties/room.py
+++ b/honeybee_doe2/properties/room.py
@@ -3,8 +3,8 @@ from typing import List
 
 from ..utils.doe_formatters import short_name
 from ..utils.geometry import get_floor_boundary
-from .wall import DoeWallObj, DoeWall
-from .roof import DoeRoofObj
+from .wall import DoeWall
+from .roof import DoeRoof
 from .groundcontact import GroundFloor
 
 
@@ -57,19 +57,19 @@ class RoomDoe2Properties(object):
         return floor_geom
 
     @property
-    def walls(self) -> List[DoeWallObj]:
+    def walls(self) -> List[DoeWall]:
         # * Needs to return list of DoeWall objects
 
         walls = [
-            DoeWallObj(face) for face in self.host.faces
+            DoeWall(face) for face in self.host.faces
             if isinstance(face.type, Wall)
         ]
         return walls
 
     @property
-    def roofs(self) -> List[DoeRoofObj]:
+    def roofs(self) -> List[DoeRoof]:
         roofs = [
-            DoeRoofObj(face) for face in self.host.faces
+            DoeRoof(face) for face in self.host.faces
             if isinstance(face.type, RoofCeiling)
         ]
         return roofs

--- a/honeybee_doe2/properties/story.py
+++ b/honeybee_doe2/properties/story.py
@@ -4,10 +4,6 @@
 from typing import List
 from honeybee.room import Room
 from honeybee.face import Face
-from honeybee.facetype import face_types
-
-from ..geometry.polygon import DoePolygon
-from ..utils.doe_formatters import short_name
 from ..utils.geometry import get_floor_boundary
 
 

--- a/honeybee_doe2/properties/wall.py
+++ b/honeybee_doe2/properties/wall.py
@@ -29,8 +29,14 @@ class DoeWall:
         obj_lines.append('\n  Y                 =  {}'.format(origin_pt.y))
         obj_lines.append('\n  Z                 =  {}'.format(origin_pt.z))
         if wall_typology == 'INTERIOR':
-            obj_lines.append(
-                '\n  NEXT-TO           =  "{}"'.format(self.face.user_data['adjacent_room']))
+            if self.face.user_data:
+                next_to = self.face.user_data['adjacent_room']
+                obj_lines.append('\n  NEXT-TO           =  "{}"'.format(next_to))
+            else:
+                print(
+                    f'{self.face.display_name} is an interior face but is missing '
+                    'adjacent room info in user data.'
+                )
         obj_lines.append('\n  ..\n')
 
         temp_str = spc.join([line for line in obj_lines])

--- a/honeybee_doe2/properties/wall.py
+++ b/honeybee_doe2/properties/wall.py
@@ -1,10 +1,8 @@
 from ..utils.doe_formatters import short_name
-from ..geometry.polygon import DoePolygon
-
 from .aperture import Window
 
 
-class DoeWallObj:
+class DoeWall:
     def __init__(self, face):
         self.face = face
 
@@ -51,38 +49,3 @@ class DoeWallObj:
 
     def __repr__(self):
         return f'DOE2 Wall: {self.face.display_name}'
-
-# ? this feels like it should be somehow linked to honeybee.face_types if that makes sense?
-# ? Like face.properties.doe2.face_obj
-
-
-class DoeWall:
-    def __init__(self, _face):
-        self._face = _face
-
-    @property
-    def face(self):
-        return self._face
-
-    @property
-    def wall_poly(self):
-        return self._make_wall_poly(self.face.geometry.polygon2d)
-
-    @staticmethod
-    def _make_wall_poly(obj):
-        return DoePolygon.from_vertices(
-            short_name(obj.display_name),
-            obj.geometry.lower_left_counter_clockwise_vertices)
-
-    @property
-    def wall_obj(self):
-        """_summary_
-
-        Returns:
-            _type_: _description_
-        """
-        return self._create_wall_obj(self.face)
-
-    @staticmethod
-    def _create_wall_obj(obj):
-        return DoeWallObj(obj)


### PR DESCRIPTION
There are two main changes here:

1. Reverse the order of vertices for floor and room vertices polygons
2. Create a separate polygon for underground floors

Generally speaking, I find the current implementation of writing the polygons separate from the main objects tricky. I suggest moving writing the DOE polygon into the `to_inp` method so you can ensure you pass the proper name to the method instead of assuming the name will be `display_name Plg`.

![image](https://user-images.githubusercontent.com/2915573/235818100-e2925408-a7cf-420d-a9f8-5f14a90cff01.png)
